### PR TITLE
menu_icon Bancho logic changed

### DIFF
--- a/nginx-1.16.1/osu/nginx.conf
+++ b/nginx-1.16.1/osu/nginx.conf
@@ -146,3 +146,30 @@ server {
         proxy_pass http://bancho;
     }
 }
+
+#assets.ppy.sh
+server {
+    listen 80;
+    server_name assets.ppy.sh;
+    return 308 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name assets.ppy.sh;
+    
+    #ssl on;
+    ssl_certificate C:/Users/uniminin/Pictures/nginx-1.16.1/osu/cert.pem;
+    ssl_certificate_key C:/Users/uniminin/Pictures/nginx-1.16.1/osu/key.pem;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_prefer_server_ciphers on;
+
+    location /menu-content.json {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://bancho;
+    }
+}

--- a/pep.py/handlers/menuIconHandler.py
+++ b/pep.py/handlers/menuIconHandler.py
@@ -1,0 +1,45 @@
+import tornado.web
+import tornado.gen
+import json
+
+from common.web import requestsManager
+from common.log import logUtils as log
+from objects import banchoConfig as bc
+
+class handler(requestsManager.asyncRequestHandler):
+	#2024년에 https://assets.ppy.sh/menu-content.json 로 바뀜
+	#Changed to https://assets.ppy.sh/menu-content.json in 2024
+	@tornado.web.asynchronous
+	@tornado.gen.engine
+	def asyncGet(self):
+		try:
+			if self.request.host.startswith("assets"):
+				imageURL = bc.banchoConfig.config["menuIcon"]
+				if imageURL:
+					url = imageURL.split("|")[1]
+					imageURL = imageURL.split("|")[0]
+					begins = expires = None
+				else:
+					imageURL = url = begins = expires = None
+
+				data = {
+					"images": [
+						{
+							"image": imageURL,
+							"url": url,
+							"IsCurrent": True,
+							"begins": begins,
+							"expires": expires
+						}
+					]
+				}
+
+				self.set_status(200)
+				self.set_header('Content-Type', "application/json")
+				self.write(json.dumps(data, indent=2))
+			else:
+				self.set_status(403)
+				self.write('Host Is Not start "assets."')
+		except Exception as e:
+			log.error(f"menuIconHandler ERROR | {e}")
+			self.set_status(500)

--- a/pep.py/pep.py
+++ b/pep.py/pep.py
@@ -23,6 +23,7 @@ from handlers import apiServerStatusHandler
 from handlers import apiVerifiedStatusHandler
 from handlers import ciTriggerHandler
 from handlers import mainHandler
+from handlers import menuIconHandler
 from handlers import heavyHandler
 from helpers import configHelper
 from helpers import consoleHelper
@@ -49,7 +50,8 @@ def make_app():
 		(r"/api/v1/ciTrigger", ciTriggerHandler.handler),
 		(r"/api/v1/verifiedStatus", apiVerifiedStatusHandler.handler),
 		(r"/api/v1/fokabotMessage", apiFokabotMessageHandler.handler),
-		(r"/stress", heavyHandler.handler)
+		(r"/stress", heavyHandler.handler),
+		(r"/menu-content.json", menuIconHandler.handler)
 	])
 
 


### PR DESCRIPTION
April 2024 The logic for fetching the menu_icon image from the client seems to have changed. [Youtube Link](https://youtu.be/UcXHSDMAbow)

https://assets.ppy.sh/menu-content.json <-- This is where we get the URL of the image and the URL to go to when clicked.
I don't know how it used to work in Bancho, but in this source code it looks like the image URL is taken from the [loadSettings() function](https://github.com/light-ripple/Light-Ripple-Windows/blob/master/pep.py/objects/banchoConfig.py#L28) , which is the code that fetches the URL from the DB, and handled by the mainHandler in pep.py. Since I already have a function to get the URLs, I added a new Handler in pep.py to get the URLs from banchoConfig.py. I also set “begins” and “expires” to null for now (they will still display correctly if left null).
The actual request comes from assets.ppy.sh, and pep.py's domain is c.ppy.sh, so when accessing https://assets.ppy.sh/menu-content.json from the nginx config file, we use proxy_pass http://bancho; to pass the request to pep.py.

Translated by deepl. XD


----------------------------------------------------------------------------------------------------


2024년 4월 클라이언트에서 menu_icon 이미지를 불러오는 로직이 변경된거 같습니다. [Youtube Link](https://youtu.be/UcXHSDMAbow)

https://assets.ppy.sh/menu-content.json <-- 이곳에서 이미지의 URL과 클릭시 이동하게 될 URL을 받아옵니다.
Bancho에서 기존 작동 방식은 모르겠는데, 이 소스코드에서는 이미지 URL을 DB에서 가져오는 코드인 [loadSettings() 함수에서](https://github.com/light-ripple/Light-Ripple-Windows/blob/master/pep.py/objects/banchoConfig.py#L28) URL을 받아서 pep.py에 있는 mainHandler에서 처리하는 것으로 보입니다. 이미 URL들을 가져오는 함수가 있으니 pep.py에 새로운 Handler를 추가하여 banchoConfig.py에서 URL을 가져오게 했습니다. 그리고 "begins", "expires"는 우선 null로 해두었습니다. (null로 해두어도 정상적으로 표시가 됨).
실재 요청은 assets.ppy.sh에서 요청이 되고 pep.py의 도메인은 c.ppy.sh 라서, nginx설정파일에서 https://assets.ppy.sh/menu-content.json 로 접속시에 proxy_pass http://bancho; 를 사용하여 pep.py쪽으로 요청을 넘깁니다.